### PR TITLE
Add GitHub issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,30 @@
+---
+name: Bug report
+about: Something isn't working as expected
+labels: bug
+---
+
+## What were you trying to do?
+
+<!-- A clear description of what you were doing when the bug occurred. -->
+
+## What happened?
+
+<!-- What actually happened — error message, crash, unexpected behavior, etc. -->
+
+## What did you expect to happen?
+
+## Environment
+
+- **sqv version** (`sqv --version`):
+- **OS**:
+- **Terminal**:
+
+## Reproduction steps
+
+<!-- Minimal steps to reproduce. A small example database or SQL to create one is very helpful. -->
+
+```sql
+-- Example: schema and data to reproduce the issue
+CREATE TABLE ...
+```

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature request
+about: Suggest a new behavior or improvement
+labels: enhancement
+---
+
+## Problem
+
+<!-- What problem are you trying to solve? Why does the current behavior fall short? -->
+
+## Proposed behavior
+
+<!-- What would you like sqv to do? Be as specific as you can about keybindings, UI, or workflow changes. -->
+
+## Alternatives considered
+
+<!-- Any other approaches you thought about, including workarounds you're using now. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,11 @@
+## What changed and why
+
+<!-- Describe the change and the motivation behind it. Link any related issues with "Fixes #..." or "Closes #...". -->
+
+## Checklist
+
+- [ ] `cargo fmt` passes
+- [ ] `cargo clippy -- -D warnings` passes
+- [ ] `cargo test` passes
+- [ ] Tests added or updated where relevant
+- [ ] Documentation updated if user-facing behavior changed


### PR DESCRIPTION
## What changed and why

Adds issue templates for bug reports and feature requests, plus a PR checklist template.

The content mirrors the guidance already in `CONTRIBUTING.md` — so reporters and contributors see consistent prompts without having to read the full contributing guide first. Nothing new is being asked of them; it's just surfaced at the right moment.

## Changes

- `.github/ISSUE_TEMPLATE/bug_report.md` — version, OS, terminal, repro steps with SQL snippet block
- `.github/ISSUE_TEMPLATE/feature_request.md` — problem / proposed behavior / alternatives
- `.github/PULL_REQUEST_TEMPLATE.md` — the four dev checks from CONTRIBUTING.md as a checklist

## Checklist

- [x] `cargo fmt` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` passes
- [x] Tests added or updated where relevant — n/a (docs only)
- [x] Documentation updated if user-facing behavior changed — n/a